### PR TITLE
Add Mocked Test For TransformedCollection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+    <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.16.1</version>
+      <scope>test</scope>
+  </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.17.0</version>

--- a/src/test/java/org/apache/commons/collections4/collection/MyTransformedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/MyTransformedCollectionTest.java
@@ -1,0 +1,54 @@
+package org.apache.commons.collections4.collection;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+// Run with `mvn test -Dtest="MyTransformedCollectionTest" -Drat.skip=true` flag.
+// The Drat skip skips an irrelevant thing that otherwise prevents the project from building
+// I had to manually import Mockito because this project uses EasyMock by default
+public class MyTransformedCollectionTest {
+    
+    // Technique: Mocked object created with @Mock annotation
+    // Obviously, there's no way you'd be mocking a list in a real application, but this is to demonstrate
+    @Mock
+    private List<Integer> myList;
+
+    @Mock
+    private Iterator<Integer> myIterator;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("Can add collection to transformed collection")
+    public void canAddCollectionToTransformedCollection() {
+        Mockito.when(myList.size()).thenReturn(5);
+        Mockito.when(myList.iterator()).thenReturn(myIterator);
+
+        AtomicInteger integer = new AtomicInteger(0); // Because annoyingly Java doesn't let me just use an int
+        // I've had to use thenAnswer a few times in personal projects
+        Mockito.when(myIterator.next()).thenAnswer(i -> integer.getAndIncrement());
+        Mockito.when(myIterator.hasNext()).thenAnswer(i -> integer.get() < 5);
+
+        TransformedCollection<Integer> collection = new TransformedCollection<>(new ArrayList<>(), a -> a * 4);
+        collection.addAll(myList);
+
+        Assertions.assertArrayEquals(
+            new Integer[] { 0, 4, 8, 12, 16 },
+            collection.toArray(new Integer[5])
+        );
+    }
+
+}


### PR DESCRIPTION
(Didn't use PR template since that's for PRs to the actual project, not BGSU's fork)

This PR's adds a Mockito @Mock annotationed test for TransformedCollection's addAll method

I’m making sure that, after calling addAll with a non-empty list, all of the items of the list are being transformed. I used this test case to demonstrate using Mockito annotations (it’s a contrived example, you’d just use an actual list in real code).
